### PR TITLE
fix: prevent github actions from running twice on pull requests from branches to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,9 @@
 name: Gradle Check
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/57120300/213900269-4321e83c-83aa-4e66-bf12-dec161b1bcf7.png)
Both the pull request and push actions trigger, this PR limits both of those to main