### PR TITLE
Automated Testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,5 @@ jobs:
       - name: Check
         run: ./gradlew check
 
-      # TODO: enable automated testing after it's implemented in the Java code
-      #- name: Automated Sim Test
-      #  run: ./gradlew simulateJavaDebug -PautomatedTest=true
+      - name: Automated Sim Test
+        run: ./gradlew simulateJavaDebug -PautomatedTest=true

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,16 @@ repositories {
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
-def ROBOT_MAIN_CLASS = (project.hasProperty('automatedTest') ? Boolean.valueOf(project.getProperty('automatedTest')) : false) ?
-		"frc.team2412.robot.AutomatedTestMain" : "frc.team2412.robot.Main"
+def getProjectBooleanProperty(String name, boolean defaultValue = false) {
+	if (!project.hasProperty(name)) {
+		return defaultValue
+	}
+	// Note that this is equivalent to 'true'.equalsIgnoreCase(project.getProperty(name))
+	// Values that are not "true" or "false" (including null) are treated as false
+	return Boolean.parseBoolean(project.getProperty(name))
+}
+
+def ROBOT_MAIN_CLASS = getProjectBooleanProperty('automatedTest') ? "frc.team2412.robot.test.AutomatedTestMain" : "frc.team2412.robot.Main"
 
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project DeployUtils.
@@ -88,7 +96,7 @@ tasks.withType(JavaCompile).configureEach {
 
 // Simulation configuration (e.g. environment variables).
 
-if (!project.hasProperty('automatedTest') || !Boolean.valueOf(project.getProperty('automatedTest'))) {
+if (!getProjectBooleanProperty('automatedTest')) {
 	wpi.sim.addGui().defaultEnabled = true
 	wpi.sim.addDriverstation()
 }

--- a/src/main/java/frc/team2412/robot/Robot.java
+++ b/src/main/java/frc/team2412/robot/Robot.java
@@ -13,7 +13,6 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj2.command.Commands;
 import frc.team2412.robot.commands.autonomous.PathPlannerTestCommand;
 import frc.team2412.robot.sim.PhysicsSim;
 import frc.team2412.robot.util.MACAddress;
@@ -130,18 +129,6 @@ public class Robot extends TimedRobot {
 	public void autonomousInit() {
 		Shuffleboard.startRecording();
 
-		Commands.waitSeconds(1)
-				.andThen(
-						Commands.runOnce(
-								() -> {
-									try {
-										int x = 1;
-										x /= 0;
-									} catch (Exception e) {
-										throw new RuntimeException("Code crash!", e);
-									}
-								}))
-				.schedule();
 		new PathPlannerTestCommand(subsystems.drivebaseSubsystem).schedule();
 	}
 

--- a/src/main/java/frc/team2412/robot/Robot.java
+++ b/src/main/java/frc/team2412/robot/Robot.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.Commands;
 import frc.team2412.robot.commands.autonomous.PathPlannerTestCommand;
 import frc.team2412.robot.sim.PhysicsSim;
 import frc.team2412.robot.util.MACAddress;
@@ -129,6 +130,18 @@ public class Robot extends TimedRobot {
 	public void autonomousInit() {
 		Shuffleboard.startRecording();
 
+		Commands.waitSeconds(1)
+				.andThen(
+						Commands.runOnce(
+								() -> {
+									try {
+										int x = 1;
+										x /= 0;
+									} catch (Exception e) {
+										throw new RuntimeException("Code crash!", e);
+									}
+								}))
+				.schedule();
 		new PathPlannerTestCommand(subsystems.drivebaseSubsystem).schedule();
 	}
 

--- a/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
@@ -101,9 +101,6 @@ public class DrivebaseSubsystem extends SubsystemBase {
 						kinematics, Rotation2d.fromDegrees(gyroscope.getYaw()), getModulePositions());
 		pose = odometry.getPoseMeters();
 
-		Object o = null;
-		o.notify();
-
 		// configure encoders offsets
 		for (int i = 0; i < moduleEncoders.length; i++) {
 			moduleEncoders[i].configFactoryDefault();

--- a/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/DrivebaseSubsystem.java
@@ -101,6 +101,9 @@ public class DrivebaseSubsystem extends SubsystemBase {
 						kinematics, Rotation2d.fromDegrees(gyroscope.getYaw()), getModulePositions());
 		pose = odometry.getPoseMeters();
 
+		Object o = null;
+		o.notify();
+
 		// configure encoders offsets
 		for (int i = 0; i < moduleEncoders.length; i++) {
 			moduleEncoders[i].configFactoryDefault();

--- a/src/main/java/frc/team2412/robot/test/AutomatedTestMain.java
+++ b/src/main/java/frc/team2412/robot/test/AutomatedTestMain.java
@@ -4,6 +4,6 @@ import edu.wpi.first.wpilibj.RobotBase;
 
 public final class AutomatedTestMain {
 	public static void main(String[] args) {
-		RobotBase.startRobot(RobotTest::getInstance);
+		RobotBase.startRobot(AutomatedTestRobot::getInstance);
 	}
 }

--- a/src/main/java/frc/team2412/robot/test/AutomatedTestMain.java
+++ b/src/main/java/frc/team2412/robot/test/AutomatedTestMain.java
@@ -1,0 +1,9 @@
+package frc.team2412.robot.test;
+
+import edu.wpi.first.wpilibj.RobotBase;
+
+public final class AutomatedTestMain {
+	public static void main(String[] args) {
+		RobotBase.startRobot(RobotTest::getInstance);
+	}
+}

--- a/src/main/java/frc/team2412/robot/test/AutomatedTestRobot.java
+++ b/src/main/java/frc/team2412/robot/test/AutomatedTestRobot.java
@@ -4,7 +4,7 @@ import edu.wpi.first.hal.simulation.DriverStationDataJNI;
 import edu.wpi.first.wpilibj.DriverStation;
 import frc.team2412.robot.Robot;
 
-public class RobotTest extends Robot {
+public class AutomatedTestRobot extends Robot {
 	private static void sleep(long durationMillis) {
 		try {
 			Thread.sleep(durationMillis);
@@ -13,14 +13,14 @@ public class RobotTest extends Robot {
 		}
 	}
 
-	private static RobotTest instance = null;
+	private static AutomatedTestRobot instance = null;
 
-	public static RobotTest getInstance() {
-		if (instance == null) instance = new RobotTest();
+	public static AutomatedTestRobot getInstance() {
+		if (instance == null) instance = new AutomatedTestRobot();
 		return instance;
 	}
 
-	private RobotTest() {
+	private AutomatedTestRobot() {
 		System.out.println("Robot type: Automated test");
 	}
 

--- a/src/main/java/frc/team2412/robot/test/AutomatedTestRobot.java
+++ b/src/main/java/frc/team2412/robot/test/AutomatedTestRobot.java
@@ -1,0 +1,70 @@
+package frc.team2412.robot.test;
+
+import edu.wpi.first.hal.simulation.DriverStationDataJNI;
+import edu.wpi.first.wpilibj.DriverStation;
+import frc.team2412.robot.Robot;
+
+public class RobotTest extends Robot {
+	private static void sleep(long durationMillis) {
+		try {
+			Thread.sleep(durationMillis);
+		} catch (InterruptedException interrupt) {
+			System.out.println("Interrupted");
+		}
+	}
+
+	private static RobotTest instance = null;
+
+	public static RobotTest getInstance() {
+		if (instance == null) instance = new RobotTest();
+		return instance;
+	}
+
+	private RobotTest() {
+		System.out.println("Robot type: Automated test");
+	}
+
+	@Override
+	public void startCompetition() {
+		try {
+			super.startCompetition();
+		} catch (Throwable throwable) {
+			Throwable cause = throwable.getCause();
+			if (cause != null) {
+				throwable = cause;
+			}
+			DriverStation.reportError(
+					"Unhandled exception: " + throwable.toString(), throwable.getStackTrace());
+			// Sleep was added to original code in
+			// https://github.com/robototes/RapidReact2022/pull/43/commits/e9e81bcae76dabe08b6f2d24eb56b55378012565
+			// sleep(2000);
+			System.exit(-1);
+		}
+	}
+
+	@Override
+	public void robotInit() {
+		super.robotInit();
+		new Thread(this::runTest).start();
+	}
+
+	private void runTest() {
+		System.out.println("Waiting two seconds for robot to finish startup");
+		sleep(2000);
+
+		System.out.println("Enabling autonomous mode and waiting 10 seconds");
+		DriverStationDataJNI.setAutonomous(true);
+		DriverStationDataJNI.setEnabled(true);
+
+		sleep(10000);
+
+		System.out.println("Disabling robot and waiting two seconds");
+		DriverStationDataJNI.setEnabled(false);
+
+		sleep(2000);
+
+		System.out.println("Ending competition");
+		suppressExitWarning(true);
+		endCompetition();
+	}
+}

--- a/src/main/java/frc/team2412/robot/test/AutomatedTestRobot.java
+++ b/src/main/java/frc/team2412/robot/test/AutomatedTestRobot.java
@@ -35,9 +35,6 @@ public class AutomatedTestRobot extends Robot {
 			}
 			DriverStation.reportError(
 					"Unhandled exception: " + throwable.toString(), throwable.getStackTrace());
-			// Sleep was added to original code in
-			// https://github.com/robototes/RapidReact2022/pull/43/commits/e9e81bcae76dabe08b6f2d24eb56b55378012565
-			// sleep(2000);
 			System.exit(-1);
 		}
 	}


### PR DESCRIPTION
Resolves #9
Same as last year, the test is run with `./gradlew simulateJavaDebug -PautomatedTest=true`, and the CI action is set up to run it on pushes and pull requests. The `automatedTest` property changes the main class to `AutomatedTestMain`, which runs `AutomatedTestRobot` instead of `Robot`.
The test runs in a separate thread that manages the robot state with `DriverStationDataJNI`, with these steps (same as last year):
1. Wait two seconds
2. Set mode to autonomous and enable robot
3. Wait ten seconds
4. Disable the robot
5. Wait two seconds
6. End the competition, which exits the program

Unhandled Java exceptions are caught and logged before exiting the program with a failure result that causes the gradle task to fail with an error.