### PR TITLE
Update to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ repositories {
 	maven { url "https://jitpack.io" }
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 def getProjectBooleanProperty(String name, boolean defaultValue = false) {
 	if (!project.hasProperty(name)) {


### PR DESCRIPTION
The roborio has java 17 on it, but our build.gradle is still using java 11

Possible benefits would be slightly better performance and the ability to use newer java features, but we might have to revert back to java 11 if the roborio image's java version gets downgraded for some reason