### PR TITLE
Revert to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ repositories {
 	maven { url "https://jitpack.io" }
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 def getProjectBooleanProperty(String name, boolean defaultValue = false) {
 	if (!project.hasProperty(name)) {


### PR DESCRIPTION
As explained in #41, updating to Java 17 has caused problems. At least 3 PRs have already included these changes, but I thought it would be cleaner to have a separate PR so that it doesn't show up in the other diffs.