### PR TITLE
Add autobalance during teleop, by holding left bumper

### DIFF
--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -52,7 +52,8 @@ public class Controls {
 								driveController::getLeftY,
 								driveController::getLeftX,
 								driveController::getRightX,
-								driveController::getRightTriggerAxis));
+								driveController::getRightTriggerAxis,
+								driveController.leftBumper()));
 		driveController.start().onTrue(new InstantCommand(s.drivebaseSubsystem::resetGyroAngle));
 		driveController.back().onTrue(new InstantCommand(s.drivebaseSubsystem::resetPose));
 	}

--- a/src/main/java/frc/team2412/robot/commands/drivebase/DriveCommand.java
+++ b/src/main/java/frc/team2412/robot/commands/drivebase/DriveCommand.java
@@ -7,6 +7,7 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.team2412.robot.subsystems.DrivebaseSubsystem;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 public class DriveCommand extends CommandBase {
@@ -17,6 +18,7 @@ public class DriveCommand extends CommandBase {
 	private final DoubleSupplier strafe;
 	private final DoubleSupplier rotation;
 	private final DoubleSupplier speedLimiter;
+	private final BooleanSupplier autoBalance;
 
 	// shuffleboard
 	private static GenericEntry driveSpeedEntry =
@@ -55,13 +57,15 @@ public class DriveCommand extends CommandBase {
 			DoubleSupplier forward,
 			DoubleSupplier strafe,
 			DoubleSupplier rotation,
-			DoubleSupplier speedLimiter) {
+			DoubleSupplier speedLimiter,
+			BooleanSupplier autoBalance) {
 		this.drivebaseSubsystem = drivebaseSubsystem;
 		this.forward = forward;
 		this.strafe = strafe;
 		this.rotation = rotation;
 		// this variable give the right trigger input
 		this.speedLimiter = speedLimiter;
+		this.autoBalance = autoBalance;
 
 		addRequirements(drivebaseSubsystem);
 	}
@@ -75,30 +79,34 @@ public class DriveCommand extends CommandBase {
 								- (speedLimiter.getAsDouble()
 										* (1 - triggerModifierEntry.getDouble(TRIGGER_MODIFIER_DEFAULT))));
 
-		double x = deadbandCorrection(-forward.getAsDouble());
-		double y = deadbandCorrection(strafe.getAsDouble());
-		double rot = deadbandCorrection(-rotation.getAsDouble());
+		if (autoBalance.getAsBoolean()) {
+			drivebaseSubsystem.drive(0, 0, new Rotation2d(), fieldOrientedEntry.getBoolean(true), true);
+		} else {
+			double x = deadbandCorrection(-forward.getAsDouble());
+			double y = deadbandCorrection(strafe.getAsDouble());
+			double rot = deadbandCorrection(-rotation.getAsDouble());
 
-		// math for normalizing and cubing inputs
-		double magnitude = Math.pow(Math.min(Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2)), 1), 3);
-		double angle = Math.atan2(y, x);
-		double cubed_x = magnitude * Math.cos(angle);
-		double cubed_y = magnitude * Math.sin(angle);
+			// math for normalizing and cubing inputs
+			double magnitude = Math.pow(Math.min(Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2)), 1), 3);
+			double angle = Math.atan2(y, x);
+			double cubed_x = magnitude * Math.cos(angle);
+			double cubed_y = magnitude * Math.sin(angle);
 
-		drivebaseSubsystem.drive(
-				(cubeSpeedEntry.getBoolean(false) ? cubed_x : x)
-						* driveSpeedModifier
-						* DrivebaseSubsystem.MAX_DRIVE_SPEED_METERS_PER_SEC, // convert from percent to m/s
-				(cubeSpeedEntry.getBoolean(false) ? cubed_y : y)
-						* driveSpeedModifier
-						* DrivebaseSubsystem.MAX_DRIVE_SPEED_METERS_PER_SEC,
-				Rotation2d.fromRotations(
-						rot
-								* rotationSpeedEntry.getDouble(1.0)
-								* DrivebaseSubsystem.MAX_ROTATIONS_PER_SEC
-										.getRotations()), // convert from percent to rotations per second
-				fieldOrientedEntry.getBoolean(true),
-				false);
+			drivebaseSubsystem.drive(
+					(cubeSpeedEntry.getBoolean(false) ? cubed_x : x)
+							* driveSpeedModifier
+							* DrivebaseSubsystem.MAX_DRIVE_SPEED_METERS_PER_SEC, // convert from percent to m/s
+					(cubeSpeedEntry.getBoolean(false) ? cubed_y : y)
+							* driveSpeedModifier
+							* DrivebaseSubsystem.MAX_DRIVE_SPEED_METERS_PER_SEC,
+					Rotation2d.fromRotations(
+							rot
+									* rotationSpeedEntry.getDouble(1.0)
+									* DrivebaseSubsystem.MAX_ROTATIONS_PER_SEC
+											.getRotations()), // convert from percent to rotations per second
+					fieldOrientedEntry.getBoolean(true),
+					false);
+		}
 	}
 
 	public double deadbandCorrection(double input) {


### PR DESCRIPTION
- Must be on ramp of charge station for this to work effectively
- This is a very basic implementation, we may want to update the ```balanceController``` in the future so that we can use this feature from all directions, however it would be fine to just leave it this way as long as drive team knows how it works and the right orientation that it can work with