### PR TITLE
Automatically add rotated driver vision to Shuffleboard

### DIFF
--- a/src/main/java/frc/team2412/robot/Subsystems.java
+++ b/src/main/java/frc/team2412/robot/Subsystems.java
@@ -9,11 +9,14 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import frc.team2412.robot.subsystems.ArmSubsystem;
 import frc.team2412.robot.subsystems.DrivebaseSubsystem;
 import frc.team2412.robot.subsystems.IntakeSubsystem;
 import frc.team2412.robot.subsystems.LEDSubsystem;
 import frc.team2412.robot.subsystems.VisionSubsystem;
+import java.util.Map;
 
 public class Subsystems {
 	public static class SubsystemConstants {
@@ -74,6 +77,10 @@ public class Subsystems {
 				// YUYV only:
 				// 2304x1296, 2304x1536
 				driverVisionCamera.setResolution(160, 120);
+				Shuffleboard.getTab("Driver vision")
+						.add("Test cam", driverVisionCamera)
+						.withWidget(BuiltInWidgets.kCameraStream)
+						.withProperties(Map.of("Show crosshair", false, "Rotation", "QUARTER_CW"));
 			}
 		}
 		if (!comp) {


### PR DESCRIPTION
Low priority, also haven't tested on bot (just ran in sim with a connected camera). Still unsure about the tab name and haven't checked that the rotation's the right way, but I thought I'll throw this out here.to review and test at some point.