### PR TITLE
Manual fine tune control during preset control

### DIFF
--- a/src/main/deploy/pathplanner/ChargeScoreLeaveComCharge.path
+++ b/src/main/deploy/pathplanner/ChargeScoreLeaveComCharge.path
@@ -16,14 +16,10 @@
       "isLocked": false,
       "isStopPoint": false,
       "stopEvent": {
-<<<<<<< Updated upstream
         "names": [
           "ScoreHigh",
           "Stow"
         ],
-=======
-        "names": [],
->>>>>>> Stashed changes
         "executionBehavior": "sequential",
         "waitBehavior": "none",
         "waitTime": 0

--- a/src/main/deploy/pathplanner/ChargeScoreLeaveComCharge.path
+++ b/src/main/deploy/pathplanner/ChargeScoreLeaveComCharge.path
@@ -16,10 +16,14 @@
       "isLocked": false,
       "isStopPoint": false,
       "stopEvent": {
+<<<<<<< Updated upstream
         "names": [
           "ScoreHigh",
           "Stow"
         ],
+=======
+        "names": [],
+>>>>>>> Stashed changes
         "executionBehavior": "sequential",
         "waitBehavior": "none",
         "waitTime": 0

--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -141,7 +141,8 @@ public class Controls {
 		wristCarryButton.onTrue(new SetFullArmCommand(s.armSubsystem, ARM_LOW_POSITION, WRIST_RETRACT));
 		wristPrescoreButton.onTrue(new SetWristCommand(s.armSubsystem, WRIST_PRESCORE));
 		wristScoreButton.onTrue(new SetWristCommand(s.armSubsystem, WRIST_SCORE));
-		wristIntakeButton.onTrue(new SetFullArmCommand(s.armSubsystem, ARM_LOW_POSITION, WRIST_SCORE));
+		wristIntakeButton.onTrue(
+				new SetFullArmCommand(s.armSubsystem, ARM_LOW_POSITION, WRIST_PRESCORE));
 	}
 
 	public void bindIntakeControls() {

--- a/src/main/java/frc/team2412/robot/Controls.java
+++ b/src/main/java/frc/team2412/robot/Controls.java
@@ -121,6 +121,9 @@ public class Controls {
 	}
 
 	public void bindArmControls() {
+		s.armSubsystem.setPresetAdjustJoysticks(
+				codriveController::getRightY, codriveController::getLeftY);
+
 		armManualControlOn.onTrue(
 				new ManualArmOverrideOnCommand(
 						s.armSubsystem, codriveController::getRightY, codriveController::getLeftY));

--- a/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
@@ -15,21 +15,17 @@ import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.BooleanSubscriber;
-import edu.wpi.first.networktables.DoubleEntry;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.DoubleSubscriber;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StringPublisher;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
-import edu.wpi.first.wpilibj.shuffleboard.WidgetType;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.team2412.robot.Robot;
 import frc.team2412.robot.sim.PhysicsSim;
-
 import java.util.Map;
 import java.util.function.DoubleSupplier;
 
@@ -104,7 +100,7 @@ public class ArmSubsystem extends SubsystemBase {
 
 		public static final Constraints WRIST_CONSTRAINTS =
 				new Constraints(MAX_WRIST_VELOCITY, MAX_WRIST_ACCELERATION);
-		
+
 		public static final double ARM_POS_ADJUST_SENSITIVITY_DEFAULT = 0.001;
 		public static final double WRIST_POS_ADJUST_SENSITIVITY_DEFAULT = 0.001;
 
@@ -197,18 +193,20 @@ public class ArmSubsystem extends SubsystemBase {
 	DoublePublisher armCurrentPublisher;
 	DoublePublisher armLastSetValuePublisher;
 
-	GenericEntry armPosAdjustSensitivity = Shuffleboard.getTab("Arm")
-											.add("Arm Adjust Sensitivity", ARM_POS_ADJUST_SENSITIVITY_DEFAULT)
-											.withSize(2, 1)
-											.withWidget(BuiltInWidgets.kNumberSlider)
-											.withProperties(Map.of("Min", 0, "Max", 0.025))
-											.getEntry();
-	GenericEntry wristPosAdjustSensitivity = Shuffleboard.getTab("Arm")
-											.add("Wrist Adjust Sensitivity", WRIST_POS_ADJUST_SENSITIVITY_DEFAULT)
-											.withSize(2, 1)
-											.withWidget(BuiltInWidgets.kNumberSlider)
-											.withProperties(Map.of("Min", 0, "Max", 0.025))
-											.getEntry();
+	GenericEntry armPosAdjustSensitivity =
+			Shuffleboard.getTab("Arm")
+					.add("Arm Adjust Sensitivity", ARM_POS_ADJUST_SENSITIVITY_DEFAULT)
+					.withSize(2, 1)
+					.withWidget(BuiltInWidgets.kNumberSlider)
+					.withProperties(Map.of("Min", 0, "Max", 0.025))
+					.getEntry();
+	GenericEntry wristPosAdjustSensitivity =
+			Shuffleboard.getTab("Arm")
+					.add("Wrist Adjust Sensitivity", WRIST_POS_ADJUST_SENSITIVITY_DEFAULT)
+					.withSize(2, 1)
+					.withWidget(BuiltInWidgets.kNumberSlider)
+					.withProperties(Map.of("Min", 0, "Max", 0.025))
+					.getEntry();
 
 	// CONSTRUCTOR
 

--- a/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
@@ -118,7 +118,7 @@ public class ArmSubsystem extends SubsystemBase {
 		 * Scoring Wrist Angle
 		 */
 		public static enum PositionType {
-			UNKNOWN_POSITION(0.212, 0.08, 0.46, 0.46),
+			UNKNOWN_POSITION(0.212, 0.08, 0.467, 0.467),
 			ARM_LOW_POSITION(0.212, 0.08, 0.46, 0.453),
 			ARM_MIDDLE_POSITION(0.415, 0.08, 0.42, 0.5),
 			ARM_HIGH_POSITION(0.6546, 0.08, 0.465, 0.473),
@@ -497,18 +497,19 @@ public class ArmSubsystem extends SubsystemBase {
 	@Override
 	public void periodic() {
 		// Periodic Arm movement for Preset Angle Control
-		if (!manualOverride && !currentPosition.equals(PositionType.UNKNOWN_POSITION)) {
+		if (!manualOverride) {
 			// fine tune adjust presets
 			double armPosAdjust =
-					(-MathUtil.applyDeadband(armPosAdjustJoystick.getAsDouble(), 0.05))
+					-MathUtil.applyDeadband(armPosAdjustJoystick.getAsDouble(), 0.05)
 							* armPosAdjustSensitivity.getDouble(ARM_POS_ADJUST_SENSITIVITY_DEFAULT);
 			double wristPosAdjust =
-					(MathUtil.applyDeadband(wristPosAdjustJoystick.getAsDouble(), 0.05))
+					MathUtil.applyDeadband(wristPosAdjustJoystick.getAsDouble(), 0.05)
 							* wristPosAdjustSensitivity.getDouble(WRIST_POS_ADJUST_SENSITIVITY_DEFAULT);
 
 			setArmGoal(armPID.getGoal().position + armPosAdjust);
 			setWristGoal((wristGoal / WRIST_MOTOR_TO_WRIST_ENCODER_RATIO) + wristPosAdjust);
-
+		}
+		if (!manualOverride && !currentPosition.equals(PositionType.UNKNOWN_POSITION)) {
 			updateArmMotorOutput();
 			updateWristMotorOutput();
 		}

--- a/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
@@ -101,8 +101,8 @@ public class ArmSubsystem extends SubsystemBase {
 		public static final Constraints WRIST_CONSTRAINTS =
 				new Constraints(MAX_WRIST_VELOCITY, MAX_WRIST_ACCELERATION);
 
-		public static final double ARM_POS_ADJUST_SENSITIVITY_DEFAULT = 0.001;
-		public static final double WRIST_POS_ADJUST_SENSITIVITY_DEFAULT = 0.001;
+		public static final double ARM_POS_ADJUST_SENSITIVITY_DEFAULT = 0.007;
+		public static final double WRIST_POS_ADJUST_SENSITIVITY_DEFAULT = 0.01;
 
 		// ENUM
 

--- a/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/team2412/robot/subsystems/ArmSubsystem.java
@@ -497,7 +497,7 @@ public class ArmSubsystem extends SubsystemBase {
 	@Override
 	public void periodic() {
 		// Periodic Arm movement for Preset Angle Control
-		if (!manualOverride) {
+		if (!manualOverride && armPosAdjustJoystick != null && wristPosAdjustJoystick != null) {
 			// fine tune adjust presets
 			double armPosAdjust =
 					-MathUtil.applyDeadband(armPosAdjustJoystick.getAsDouble(), 0.05)


### PR DESCRIPTION
Enables fine tune manual control during preset control

With this change, if the presets get off or look wrong to drive team at some time, they can manually adjust the position with joysticks. It all still uses a position PID loop, so wrist and arm stay in place when moving unlike true manual control. The adjustments do not save to the presets which we may want to change in the future. It would be cool to save the preset locations in NT as persistent values. 